### PR TITLE
[🐸 Frogbot] Update version of org.codehaus.jackson:jackson-mapper-asl to 1.9.13-cloudera.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
         <groovy.range>[4.0,5.0)</groovy.range>
         <gmaven.version>1.5</gmaven.version>
         <hamcrest.version>2.2</hamcrest.version>
-        <jackson1.version>1.9.11</jackson1.version>
+        <jackson1.version>1.9.13-cloudera.3</jackson1.version>
         <jackson2.version>2.17.1</jackson2.version>
         <johnzon.version>1.1.11</johnzon.version>
         <yasson.version>1.0.6</yasson.version>


### PR DESCRIPTION


[comment]: <> (FrogbotReviewComment)

<div align='center'>

[![🚨 This automated pull request was created by Frogbot and fixes the below:](https://raw.githubusercontent.com/jfrog/frogbot/master/resources/v2/vulnerabilitiesFixBannerPR.png)](https://docs.jfrog-applications.jfrog.io/jfrog-applications/frogbot)

</div>



### 📦 Vulnerable Dependencies

<div align='center'>

| Severity                | ID                  | Contextual Analysis                  | Direct Dependencies                  | Impacted Dependency                  | Fixed Versions                  |
| :---------------------: | :-----------------------------------: | :-----------------------------------: | :-----------------------------------: | :-----------------------------------: | :-----------------------------------: |
| ![critical (not applicable)](https://raw.githubusercontent.com/jfrog/frogbot/master/resources/v2/notApplicableCritical.png)<br>Critical | CVE-2019-14892 | Not Applicable | org.codehaus.jackson:jackson-jaxrs:1.9.11<br>io.rest-assured:scala-support:5.5.6-SNAPSHOT<br>io.rest-assured:json-path:5.5.6-SNAPSHOT<br>io.rest-assured:spring-web-test-client:5.5.6-SNAPSHOT<br>io.rest-assured:spring-mock-mvc:5.5.6-SNAPSHOT<br>io.rest-assured:rest-assured:5.5.6-SNAPSHOT<br>io.rest-assured:kotlin-extensions:5.5.6-SNAPSHOT<br>io.rest-assured:scala-extensions:5.5.6-SNAPSHOT | org.codehaus.jackson:jackson-mapper-asl 1.9.11 | [1.8.10-cloudera.3]<br>[1.9.13-cloudera.3] |

</div>


### 🔖 Details



### Vulnerability Details
|                 |                   |
| --------------------- | :-----------------------------------: |
| **Policies:** | policy-sanity_maven_rest_assured_commit-1754918714 |
| **Watch Name:** | watch-sanity_maven_rest_assured_commit-1754918714 |
| **Jfrog Research Severity:** | <img src="https://raw.githubusercontent.com/jfrog/frogbot/master/resources/v2/smallMedium.svg" alt=""/> Medium |
| **Contextual Analysis:** | Not Applicable |
| **Direct Dependencies:** | org.codehaus.jackson:jackson-jaxrs:1.9.11, io.rest-assured:scala-support:5.5.6-SNAPSHOT, io.rest-assured:json-path:5.5.6-SNAPSHOT, io.rest-assured:spring-web-test-client:5.5.6-SNAPSHOT, io.rest-assured:spring-mock-mvc:5.5.6-SNAPSHOT, io.rest-assured:rest-assured:5.5.6-SNAPSHOT, io.rest-assured:kotlin-extensions:5.5.6-SNAPSHOT, io.rest-assured:scala-extensions:5.5.6-SNAPSHOT |
| **Impacted Dependency:** | org.codehaus.jackson:jackson-mapper-asl:1.9.11 |
| **Fixed Versions:** | [1.8.10-cloudera.3], [1.9.13-cloudera.3] |
| **CVSS V3:** | 9.8 |

A typing issue in commons-configuration in Jackson-databind leads to unknown impact.

### 🔬 JFrog Research Details

**Description:**
[Jackson-databind]( https://github.com/FasterXML/jackson-databind) (previously known as "jackson-mapper-asl") is a streaming API library for Java. One of its components, `ObjectMapper` is responsible for serialization and deserialization of Java objects.
Jackson also supports deserialization of polymorphic types when `default typing` is enabled. This can be enabled by adding `@JsonTypeInfo(use = Id.CLASS) ` according to your function to determine its type or by calling `enableDefaultTyping()` on your `Objectmapper`..
This identifier allows the `ObjectMapper` to accept type identifiers and interpret them as an object like so:
```
{ "phone" : {
 "@class" : "package.InternationalNumber",
 "areaCode" : 555,
 ...
 }
}
```

`ObjectMapper` can accept inputs from various of sources such as files, URL, JSON, web requests and many more, for example:
```
// Object from local JSON file
Phone p = ObjectMapper.readValue(new File("phone.json"), Phone.class);
Or
// Object from HTTP-hosted JSON file
Phone p = ObjectMapper.readValue(new URL("https://www.somedomain.com/src/test/json_car.json"), Phone.class);

```

Support for polymorphic type deserialization allows an attacker to create almost any class at the server-side, assuming an attacker-supplied JSON file is deserialized. 
A vulnerable server-side handling of the serialized data may look like this:

```
ObjectMapper mapper = new ObjectMapper();
mapper.enableDefaultTyping()
obj = mapper.readValue(jsonContent, java.lang.Object.java_class)
```

The server-side creates the desired object by calling `mapper.readValue(…)` which will call all of its setters with the arguments supplied within the request.

To exploit this issue, an attacker has to find code modules or functions included in the Java classpath that aren’t [blacklisted](https://github.com/FasterXML/jackson-databind/blob/9593e16cf5a3d289a9c584f7123639655de9ddac/src/main/java/com/fasterxml/jackson/databind/jsontype/impl/SubTypeValidator.java) by Jackson-databind, that will allow the attacker to perform operations with some security impact (such as remote code injection) when chained together. These code modules are also known as [gadgets]( https://vickieli.dev/insecure%20deserialization/java-deserialization/).

Specifically, the `org.apache.commons.configuration.JNDIConfiguration` gadget in [commons-configuration](https://github.com/apache/commons-configuration) might allow remote code execution but this is nontrivial and has never been proven publicly, thus the real-world impact is uncertain.

Exploitation requires:

-	 Default typing enabled for external JSON endpoints
-	The vulnerable java service includes ` commons-configuration ` in its Java classpath
-	The service has polymorphic type handling enabled
-	The service deserializes objects with nominal type of `java.lang.Object`.

**Remediation:**
##### Deployment mitigations

Remove `commons-configuration` from your Java classpath with the help of [this guide](https://docs.oracle.com/javase/tutorial/essential/environment/paths.html)

##### Development mitigations

Avoid using `java.lang.Object` as the deserialized object type. For example, a vulnerable usage would be - `obj = mapper.readValue(content, java.lang.Object.java_class)`. Instead - try to deserialize to the specific object type that you need, instead of `java.lang.Object`

##### Development mitigations

Avoid enabling default typing (`mapper.enableDefaultTyping()`)



---
<div align='center'>

[🐸 JFrog Frogbot](https://docs.jfrog-applications.jfrog.io/jfrog-applications/frogbot)

</div>
